### PR TITLE
fix: Implement dispense notifications and resolve build errors

### DIFF
--- a/PawfeedsProvisioner.csproj
+++ b/PawfeedsProvisioner.csproj
@@ -27,6 +27,9 @@
   
   <!-- Add Firestore package used by FirestoreService.cs -->
   <PackageReference Include="Plugin.Firebase.Firestore" Version="3.0.0" />
+
+  <!-- Add Cloud Messaging package for push notifications -->
+  <PackageReference Include="Plugin.Firebase.CloudMessaging" Version="3.0.0" />
   <!-- The Plugin.Firebase.Auth package was removed as AuthService.cs uses FirebaseAuthentication.net instead -->
   
   <!-- Other libraries -->

--- a/Services/FirestoreService.cs
+++ b/Services/FirestoreService.cs
@@ -61,9 +61,10 @@ namespace PawfeedsProvisioner.Services
                 var data = new Dictionary<string, object>
                 {
                     { "fcmToken", token },
-                    { "lastSeen", FieldValue.ServerTimestamp } // Good practice to update a timestamp
+                    { "lastSeen", FieldValue.ServerTimestamp() } // Correct: Invoke the method
                 };
-                await userRef.SetDocumentAsync(data, SetOptions.MergeAll);
+                // Correct: Use SetAsync and SetOptions.Merge()
+                await userRef.SetAsync(data, SetOptions.Merge());
                 Console.WriteLine($"[FirestoreService] FCM token successfully updated for user {uid}.");
             }
             catch (Exception ex)


### PR DESCRIPTION
This commit introduces push notifications for scheduled dispense events and resolves several compilation errors in the mobile application.

On the mobile app, this change adds and configures the `Plugin.Firebase.CloudMessaging` package. It updates the login process to retrieve the user's FCM token and store it in their Firestore document. It also corrects the Firestore API calls in `FirestoreService.cs` to resolve build failures.

On the backend, a new HTTP-triggered cloud function, `onDispense`, has been created. This function is called by a webhook from the pet feeder and sends a push notification to the device owner. The `package-lock.json` was also regenerated to ensure dependency consistency.